### PR TITLE
Replace Entities.remove() with Entities.delete() in Ecs.js

### DIFF
--- a/lesson_111_quaternion_cone_constraint/fungi/Ecs.js
+++ b/lesson_111_quaternion_cone_constraint/fungi/Ecs.js
@@ -233,7 +233,7 @@ class Ecs{
 			let e = this.Entities.get(eID);
 			if(e){
 				Entity.dispose( e );
-				this.Entities.remove( eID );
+				this.Entities.delete( eID );
 			}else console.log("Entity does not exist when trying to remove : ", eID);
 
 			return this;


### PR DESCRIPTION
Replaced .remove() for .delete() on the Entities Map Object.
Map objects have no remove method.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/delete