### PR TITLE
replaced arguments with spread operator

### DIFF
--- a/lesson_134_data_texture_skin_animation/fungi/engine/lib/Downloader.js
+++ b/lesson_134_data_texture_skin_animation/fungi/engine/lib/Downloader.js
@@ -65,8 +65,8 @@ class Downloader{
 		}
 
 		// Easier to pass in group of shaders, so first arg is the handler, then every arg after is just a file to download.
-		addGrp( handler, file ){
-			for( let i=1; i < arguments.length; i++ ) this.add( handler, arguments[ i ] );
+		addGrp( handler, ...files ){
+			files.forEach(f => this.add(handler, f));
 			return this;
 		}
 

--- a/lesson_134_data_texture_skin_animation/fungi/engine/lib/Downloader.js
+++ b/lesson_134_data_texture_skin_animation/fungi/engine/lib/Downloader.js
@@ -66,7 +66,7 @@ class Downloader{
 
 		// Easier to pass in group of shaders, so first arg is the handler, then every arg after is just a file to download.
 		addGrp( handler, ...files ){
-			files.forEach(f => this.add(handler, f));
+			for(const file of files) this.add(handler, f);
 			return this;
 		}
 


### PR DESCRIPTION
argumants is an old mechanism and I wouldn't be suprised if it were to be removed.